### PR TITLE
Root url cannot be stripped of trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ functions:
 
 plugins:
   - serverless-offline
+
+custom:
+  serverless-offline:
+    noStripTrailingSlashInUrl: true
+
 ```
 
 


### PR DESCRIPTION
Fixes https://github.com/supercharge/hapi-aws-lambda/issues/12